### PR TITLE
Add a Dockerfile to start a on-premise server quickly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.5.3
+RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+WORKDIR /myapp
+COPY Gemfile /myapp/Gemfile
+COPY Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+
+COPY . /myapp/
+RUN RAILS_ENV=production bundle exec rake assets:precompile
+CMD ["/bin/sh", "-c", "grep web: Procfile | cut -d : -f2 | sh"]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,31 @@ This is Sticky Notes app's backend project.
 
 The backend provides data storage, data sync,
 and user management for Sticky Notes apps.
+
+
+## Self Host with Docker
+
+
+You can try the backend server with docker and launch an instance with a postgres database like this:
+```
+git clone https://github.com/kumabook/stickynotes-backend.git
+sudo docker-compose up
+```
+
+Here is an example of reverse proxy configuration
+
+cat /etc/nginx/sites-enabled/stickynotes.conf
+```
+server {
+   listen 443 ssl;
+   listen [::]:443 ssl http2;
+   server_name my.stickynotes.com;
+   location / {
+       proxy_pass         http://127.0.0.1:3000/;
+       proxy_set_header   Host $host;
+       proxy_set_header   X-Real-IP $remote_addr;
+       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header   X-Forwarded-Proto $scheme;
+   }
+}
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+services:
+    db:
+        image: "postgres:10"
+        environment:
+            - "POSTGRES_PASSWORD=stickynotes"
+            - "POSTGRES_USER=stickynotes"
+            - "POSTGRES_DB=stickynotes"
+        volumes:
+            - "./pg_data:/var/lib/postgresql/data"
+    stickynotes:
+        build: "."
+        ports: 
+            - "3000:3000"
+        depends_on:
+            - db
+        environment:
+            - RAILS_ENV=production
+            - SECRET_KEY_BASE=e13e6c16954bfa1d542cd20108a35b7dce7b034f8dfc575d7c165192ece88cf34dabc428f68b52bdc690133224869608c42076ffdf910d43837dc03d2e3eccb4
+            - RDS_DB_NAME=stickynotes
+            - RDS_USERNAME=stickynotes
+            - RDS_PASSWORD=stickynotes
+            - RDS_HOSTNAME=db
+            - RDS_PORT=5432
+            - RAILS_LOG_TO_STDOUT=true


### PR DESCRIPTION
Hi !

I came across your extension on the addons.mozilla.org and really like the concept, congratulations. I saw the [discution](https://github.com/kumabook/stickynotes/issues/131) about onpremise servers and I started my own instance.

Here is a working Dockerfile that could be usefull especially for people not familiar with rails. There is also a docker-compose yaml file to start an instance quickly.

Now, I am going to make a another Push Request on the webextension projet, in order to easily change the backend url.

Regards,
Pascal Noisette